### PR TITLE
Add simple tests and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,21 @@
+name: Python Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest -v

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+# Add dist folder to import path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "dist"))
+
+from rename import get_episode_from_id, get_episode_from_nfo, get_episode_from_media, Episode, SHOW_NAME
+
+
+def test_get_episode_from_id():
+    ep = get_episode_from_id("One Pace", "S05E02")
+    assert ep.show == "One Pace"
+    assert ep.season == 5
+    assert ep.number == 2
+
+
+def test_get_episode_from_nfo(tmp_path):
+    fname = "One Pace - S02E03 - Cool Title.nfo"
+    path = tmp_path / fname
+    path.write_text("")
+    ep = get_episode_from_nfo(path)
+    assert ep.title == "Cool Title"
+    assert ep.season == 2
+    assert ep.number == 3
+    assert ep.extended is False
+
+
+def test_get_episode_from_media(tmp_path):
+    fname = "[One Pace][1] TestArc 05 [1080p][ABC123].mkv"
+    path = tmp_path / fname
+    path.write_text("")
+    seasons = {"TestArc": 1}
+    ep = get_episode_from_media(path, seasons)
+    assert ep.show == SHOW_NAME
+    assert ep.season == 1
+    assert ep.number == 5
+    assert ep.extended is False

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "dist"))
+
+from transcode import parse_nfo
+
+
+def test_parse_nfo(tmp_path):
+    xml_content = """<?xml version='1.0' encoding='UTF-8'?>
+<episodedetails>
+  <title>Test Title</title>
+  <showtitle>One Pace</showtitle>
+  <season>1</season>
+  <episode>10</episode>
+</episodedetails>
+"""
+    nfo_file = tmp_path / "test.nfo"
+    nfo_file.write_text(xml_content)
+    result = parse_nfo(nfo_file)
+    assert result == {
+        "title": "Test Title",
+        "showtitle": "One Pace",
+        "season": "1",
+        "episode": "10",
+    }


### PR DESCRIPTION
## Summary
- add pytest-based tests for `rename.py` and `transcode.py`
- create a GitHub Actions workflow running these tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68613cf7e808832690e17903dae77e7c