### PR TITLE
Enhance transcode metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ After renaming you can convert the episodes to MP4 using the x265 codec and embe
 
 1. Copy `transcode.py` from the `/dist/` folder to your `One Pace` directory.
 2. Run `python3 transcode.py --dry-run` to view the ffmpeg commands that would be executed.
-3. When satisfied remove `--dry-run` to transcode the files. Use `--replace` if you want the original files deleted after conversion.
+3. When satisfied remove `--dry-run` to transcode the files. Use `--replace` if you want the original files deleted after conversion. Pass `--embed-artwork` to automatically attach the season poster to each episode.
 
 ```
     python3 transcode.py --replace
 ```
 
-The script requires `ffmpeg` to be installed and will embed title, show title, season and episode metadata into the resulting `.mp4` file.
+The script requires `ffmpeg` to be installed and will embed title, show title, season and episode metadata into the resulting `.mp4` file. Additional metadata like the One Pace arc name, original anime episode references and optional cover artwork are also included.
 
 ### 6. Install XBMCnfoTVImporter
 

--- a/dist/transcode.py
+++ b/dist/transcode.py
@@ -8,6 +8,7 @@ matching .nfo file is embedded into the resulting mp4 file.
 
 import argparse
 import logging
+import re
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -31,23 +32,70 @@ def parse_nfo(nfo_path: Path) -> dict[str, str]:
     return fields
 
 
-def transcode_file(media_path: Path, replace: bool, dry_run: bool) -> None:
+def parse_additional_metadata(nfo_path: Path, media_path: Path) -> dict[str, str]:
+    """Extract extra fields like original episode numbers and arc name."""
+    extras: dict[str, str] = {}
+
+    try:
+        tree = ET.parse(nfo_path)
+        root = tree.getroot()
+    except ET.ParseError as exc:
+        logger.warning("Failed to parse %s: %s", nfo_path, exc)
+        return extras
+
+    plot = root.find("plot")
+    if plot is not None and plot.text:
+        match = re.search(r"Anime Episode\(s\):\s*(.*)", plot.text)
+        if match:
+            extras["original_episode"] = match.group(1).strip()
+
+    season_nfo = media_path.parent / "season.nfo"
+    if season_nfo.exists():
+        try:
+            sroot = ET.parse(season_nfo).getroot()
+            title_el = sroot.find("title")
+            if title_el is not None and title_el.text:
+                title = title_el.text
+                if "." in title:
+                    title = title.split(".", 1)[1]
+                extras["onepace_arc"] = title.strip()
+        except ET.ParseError:
+            pass
+
+    return extras
+
+
+def transcode_file(media_path: Path, replace: bool, dry_run: bool, embed_artwork: bool) -> None:
     nfo_path = media_path.with_suffix(".nfo")
     if not nfo_path.exists():
         logger.warning("Skipping %s: missing nfo", media_path)
         return
 
     meta = parse_nfo(nfo_path)
+    meta.update(parse_additional_metadata(nfo_path, media_path))
     output_path = media_path.with_suffix(MP4_EXT)
-    cmd = [
-        "ffmpeg",
-        "-i",
-        str(media_path),
+    poster = None
+    if embed_artwork and "season" in meta:
+        try:
+            season_num = int(meta["season"])
+            poster_name = f"season{season_num:02d}-poster.png"
+            candidate = media_path.parents[1] / poster_name
+            if candidate.exists():
+                poster = candidate
+        except ValueError:
+            pass
+
+    cmd = ["ffmpeg", "-i", str(media_path)]
+    if poster:
+        cmd += ["-i", str(poster)]
+    cmd += [
         "-c:v",
         "libx265",
         "-c:a",
         "copy",
     ]
+    if poster:
+        cmd += ["-map", "0", "-map", "1", "-disposition:v:1", "attached_pic"]
     for key, value in meta.items():
         ffkey = {
             "showtitle": "show",
@@ -68,13 +116,13 @@ def transcode_file(media_path: Path, replace: bool, dry_run: bool) -> None:
         output_path.rename(media_path)
 
 
-def scan_directory(directory: Path, replace: bool, dry_run: bool) -> None:
+def scan_directory(directory: Path, replace: bool, dry_run: bool, embed_artwork: bool) -> None:
     for file in directory.rglob(f"*{MKV_EXT}"):
-        transcode_file(file, replace, dry_run)
+        transcode_file(file, replace, dry_run, embed_artwork)
     for file in directory.rglob(f"*{MP4_EXT}"):
         if file.suffix == MP4_EXT:
             continue
-        transcode_file(file, replace, dry_run)
+        transcode_file(file, replace, dry_run, embed_artwork)
 
 
 def main() -> None:
@@ -90,9 +138,14 @@ def main() -> None:
     parser.add_argument(
         "--dry-run", action="store_true", help="Show ffmpeg commands without executing"
     )
+    parser.add_argument(
+        "--embed-artwork",
+        action="store_true",
+        help="Embed season poster as cover art when available",
+    )
     args = parser.parse_args()
 
-    scan_directory(Path(args.directory), args.replace, args.dry_run)
+    scan_directory(Path(args.directory), args.replace, args.dry_run, args.embed_artwork)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add new options and metadata extraction to `transcode.py`
- allow embedding season posters as artwork
- document new behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686155fe67548326a55e920d10a5c48f