### PR TITLE
Handle quoted directory paths

### DIFF
--- a/dist/transcode.py
+++ b/dist/transcode.py
@@ -40,6 +40,8 @@ def prompt_directory(default: Path = Path(".")) -> Path:
     """Prompt the user for a directory, verifying existence."""
     while True:
         resp = input(f"Directory containing episodes [{default}]: ").strip()
+        # Handle Windows paths entered with surrounding quotes
+        resp = resp.strip('"').strip("'")
         path = Path(resp or default).expanduser()
         if path.exists():
             return path

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -24,3 +24,17 @@ def test_parse_nfo(tmp_path):
         "season": "1",
         "episode": "10",
     }
+
+from transcode import prompt_directory
+
+
+def test_prompt_directory_handles_quotes(tmp_path, monkeypatch):
+    quoted = tmp_path / "with space"
+    quoted.mkdir()
+
+    def fake_input(prompt):
+        return f'"{quoted}"'
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    result = prompt_directory()
+    assert result == quoted


### PR DESCRIPTION
## Summary
- tolerate quoted UNC paths in interactive prompt
- test prompt_directory to ensure quotes are stripped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68627d51731483268ef7c6c5331819c6