### PR TITLE
Add plot metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ After renaming you can convert the episodes to MP4 using the x265 codec and embe
     python3 transcode.py --replace
 ```
 
-The script requires `ffmpeg` to be installed and will embed title, show title, season and episode metadata into the resulting `.mp4` file. Additional metadata like the One Pace arc name, original anime episode references and optional cover artwork are also included.
+The script requires `ffmpeg` to be installed and will embed title, show title, season and episode metadata into the resulting `.mp4` file. Additional metadata like episode descriptions, the One Pace arc name, original anime episode references and optional cover artwork are also included.
 
 ### 6. Install XBMCnfoTVImporter
 

--- a/dist/transcode.py
+++ b/dist/transcode.py
@@ -53,10 +53,20 @@ def parse_nfo(nfo_path: Path) -> dict[str, str]:
     tree = ET.parse(nfo_path)
     root = tree.getroot()
     fields = {}
-    for tag in ["title", "showtitle", "season", "episode"]:
+    for tag in ["title", "showtitle", "season", "episode", "plot"]:
         el = root.find(tag)
         if el is not None and el.text:
-            fields[tag] = el.text
+            if tag == "plot":
+                description_lines = []
+                for line in el.text.splitlines():
+                    if line.strip().startswith("Manga Chapter(s):"):
+                        continue
+                    if line.strip().startswith("Anime Episode(s):"):
+                        continue
+                    description_lines.append(line)
+                fields["description"] = "\n".join(description_lines).strip()
+            else:
+                fields[tag] = el.text
     return fields
 
 

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -13,6 +13,7 @@ def test_parse_nfo(tmp_path):
   <showtitle>One Pace</showtitle>
   <season>1</season>
   <episode>10</episode>
+  <plot>This is a test description.</plot>
 </episodedetails>
 """
     nfo_file = tmp_path / "test.nfo"
@@ -23,6 +24,7 @@ def test_parse_nfo(tmp_path):
         "showtitle": "One Pace",
         "season": "1",
         "episode": "10",
+        "description": "This is a test description.",
     }
 
 from transcode import prompt_directory


### PR DESCRIPTION
## Summary
- read episode descriptions from `.nfo` files when transcoding
- include description in ffmpeg metadata
- document extra metadata capability
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863ad99b7f483269f5c78cc9bbab2d3